### PR TITLE
fix(docs): adjust link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 Generate URLs for the Nextcloud front-end
 
-Documentation: https://nextcloud.github.io/nextcloud-router/
+Documentation: https://nextcloud-libraries.github.io/nextcloud-router/


### PR DESCRIPTION
This just fixes the link to the docs after the repository got moved.