### PR TITLE
fix: Adjust `generateFilePath` to include `type` also for `index.php`

### DIFF
--- a/__tests__/paths.spec.ts
+++ b/__tests__/paths.spec.ts
@@ -48,9 +48,8 @@ describe('Path generation', () => {
 			expect(generateFilePath('forms', '', 'index.php')).toBe('/index.php/apps/forms')
 		})
 
-		// TODO: This feels wrong, I would expect `/index.php/apps/forms/templates`
 		test('non core PHP index files with type', () => {
-			expect(generateFilePath('forms', 'templates', 'index.php')).toBe('/index.php/apps/forms')
+			expect(generateFilePath('forms', 'templates', 'index.php')).toBe('/index.php/apps/forms/templates')
 		})
 
 		test('non core PHP file', () => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -151,13 +151,12 @@ export const generateFilePath = (app: string, type: string, file: string) => {
 	const isCore = window?.OC?.coreApps?.indexOf(app) !== -1
 	let link = getRootUrl()
 	if (file.substring(file.length - 3) === 'php' && !isCore) {
-		link += '/index.php/apps/' + app
+		link += `/index.php/apps/${app}`
+		if (type) {
+			link += `/${encodeURI(type)}`
+		}
 		if (file !== 'index.php') {
-			link += '/'
-			if (type) {
-				link += encodeURI(type + '/')
-			}
-			link += file
+			link += `/${file}`
 		}
 	} else if (file.substring(file.length - 3) !== 'php' && !isCore) {
 		link = getAppRootUrl(app)


### PR DESCRIPTION
It seemed to me wrong that `generateFilePath('app', 'type 'index.php')` would ignore the type, currently it returns `'/index.php/apps/app/'` where I would expect `'/index.php/apps/app/type'`.