### PR TITLE
fix(getRootUrl)!: If not configured use first subdirectory as webroot instead of last

### DIFF
--- a/__tests__/webroot.spec.ts
+++ b/__tests__/webroot.spec.ts
@@ -57,12 +57,25 @@ describe('Web root handling', () => {
 		expect(getBaseUrl()).toBe(`${window.location.origin}/nextcloud`)
 	})
 
-	// TODO: This seems to be wrong, would expect `/nextcloud`
+	test('with implicit empty web root', () => {
+		window._oc_webroot = undefined
+		window.location.pathname = '/'
+		expect(getRootUrl()).toBe('/')
+		expect(getBaseUrl()).toBe(`${window.location.origin}/`)
+	})
+
 	test('with implicit web root and path rename', () => {
 		window._oc_webroot = undefined
+		window.location.pathname = '/nextcloud'
+		expect(getRootUrl()).toBe('/nextcloud')
+		expect(getBaseUrl()).toBe(`${window.location.origin}/nextcloud`)
+	})
+
+	test('with implicit web root on route with path rename', () => {
+		window._oc_webroot = undefined
 		window.location.pathname = '/nextcloud/apps/files'
-		expect(getRootUrl()).toBe('/nextcloud/apps')
-		expect(getBaseUrl()).toBe(`${window.location.origin}/nextcloud/apps`)
+		expect(getRootUrl()).toBe('/nextcloud')
+		expect(getBaseUrl()).toBe(`${window.location.origin}/nextcloud`)
 	})
 })
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -227,7 +227,9 @@ export function getRootUrl(): string {
 		if (pos !== -1) {
 			webroot = webroot.slice(0, pos)
 		} else {
-			webroot = webroot.slice(0, webroot.lastIndexOf('/'))
+			const index = webroot.indexOf('/', 1)
+			// Make sure to not cut end of path if there is just the webroot like `/nextcloud`
+			webroot = webroot.slice(0, index > 0 ? index : undefined)
 		}
 	}
 	return webroot


### PR DESCRIPTION
Situation: Webserver configured for path rewrite (remove the `index.php`):

Before:
* Current path: `/nextcloud/apps/files`
* Result of `getRoot()`: `/nextcloud/apps`

After:
* Current path: `/nextcloud/apps/files`
* Result of `getRoot()`: `/nextcloud`

This affects only situations where the web root is not correctly configured by Nextcloud, but I think we should then only expect the first sub-directory to be the web root instead of all directories.