### PR TITLE
fix: Use files whitelist instead of .npmignore to only include needed files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-node_modules/
-.github
-tsconfig.json
-babel.config.js

--- a/package.json
+++ b/package.json
@@ -52,5 +52,11 @@
   "engines": {
     "node": "^20.0.0",
     "npm": "^10.0.0"
-  }
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md",
+    "README.md",
+    "LICENSE"
+  ]
 }


### PR DESCRIPTION
Prevent useless files like vite config from being included in release bundle.